### PR TITLE
Fix(opportunities): Details button not working

### DIFF
--- a/webApps/app/flows/opportunities/pages/opportunities-details-page.html
+++ b/webApps/app/flows/opportunities/pages/opportunities-details-page.html
@@ -17,7 +17,7 @@
             <oj-bind-text value="[[ $flow.variables.opty.name ]]"></oj-bind-text>
           </div>
           <div class="oj-flex">
-            <oj-button label="Details" chroming="outlined">
+            <oj-button label="Details" chroming="outlined" on-oj-action="[[$page.listeners.navigateToEditDetails]]">
               <span class="oj-ux-ico-add-edit-page" slot="startIcon"></span>
             </oj-button>
           </div>
@@ -422,4 +422,3 @@
     </div>
   </div>
 </div>
-


### PR DESCRIPTION
This pull request fixes a bug where the 'details' button on the 'opportunities-detail' page was not working. The issue was that the `oj-button` element was missing the `on-oj-action` attribute, which is necessary to trigger the navigation to the edit page.

This has been resolved by adding the `on-oj-action` attribute and setting its value to `[[$page.listeners.navigateToEditDetails]]` to the button.