### PR TITLE
Fix details button

### DIFF
--- a/webApps/app/flows/opportunities/pages/opportunities-details-page.html
+++ b/webApps/app/flows/opportunities/pages/opportunities-details-page.html
@@ -17,8 +17,8 @@
             <oj-bind-text value="[[ $flow.variables.opty.name ]]"></oj-bind-text>
           </div>
           <div class="oj-flex">
-            <oj-button label="Details" chroming="outlined">
-              <span class="oj-ux-ico-add-edit-page" slot="startIcon"></span>
+            <oj-button label="Edit" chroming="outlined" on-oj-action="[[$listeners.ojButtonOjAction]]">
+              <span class="oj-ux-ico-edit" slot="startIcon"></span>
             </oj-button>
           </div>
         </div>
@@ -422,4 +422,3 @@
     </div>
   </div>
 </div>
-


### PR DESCRIPTION
This PR fixes the details button on the opportunities-detail page. It adds an `on-oj-action` event to the button and changes the label to "Edit".