### PR TITLE
Fix: Details Button Not Working on opportunities-detail Page

### DIFF
--- a/webApps/app/flows/opportunities/pages/opportunities-details-page.html
+++ b/webApps/app/flows/opportunities/pages/opportunities-details-page.html
@@ -17,7 +17,7 @@
             <oj-bind-text value="[[ $flow.variables.opty.name ]]"></oj-bind-text>
           </div>
           <div class="oj-flex">
-            <oj-button label="Details" chroming="outlined">
+            <oj-button label="Details" chroming="outlined" on-oj-action="[[$listeners.navigateToEdit]]">
               <span class="oj-ux-ico-add-edit-page" slot="startIcon"></span>
             </oj-button>
           </div>
@@ -422,4 +422,3 @@
     </div>
   </div>
 </div>
-


### PR DESCRIPTION
This pull request fixes a non-functional “Details” button on the opportunities-detail page. The issue was resolved by adding an `on-oj-action` attribute to the button in the HTML file and defining the corresponding event listener in the JSON file. These changes ensure that clicking the button triggers the navigation to the details edit page.