### PR TITLE
Fix: 'Details' button on opportunities detail page not working

### DIFF
--- a/webApps/app/flows/opportunities/pages/opportunities-details-page.html
+++ b/webApps/app/flows/opportunities/pages/opportunities-details-page.html
@@ -17,7 +17,7 @@
             <oj-bind-text value="[[ $flow.variables.opty.name ]]"></oj-bind-text>
           </div>
           <div class="oj-flex">
-            <oj-button label="Details" chroming="outlined">
+            <oj-button label="Details" chroming="outlined" on-oj-action="[[$listeners.navigateToEdit]]">
               <span class="oj-ux-ico-add-edit-page" slot="startIcon"></span>
             </oj-button>
           </div>
@@ -422,4 +422,3 @@
     </div>
   </div>
 </div>
-


### PR DESCRIPTION
This pull request fixes a bug where the 'details' button on the opportunities detail page was not working. The bug was caused by a missing on-oj-action attribute on the button. The fix adds the on-oj-action attribute and sets it to call the navigateToEdit event.