### PR TITLE
fix(details): fix details button and rename to edit

### DIFF
--- a/webApps/app/flows/opportunities/pages/opportunities-details-page.html
+++ b/webApps/app/flows/opportunities/pages/opportunities-details-page.html
@@ -17,7 +17,7 @@
             <oj-bind-text value="[[ $flow.variables.opty.name ]]"></oj-bind-text>
           </div>
           <div class="oj-flex">
-            <oj-button label="Details" chroming="outlined">
+            <oj-button label="Edit" chroming="outlined" on-oj-action="[[$listeners.navigateDetailsEditPageActionChain]]">
               <span class="oj-ux-ico-add-edit-page" slot="startIcon"></span>
             </oj-button>
           </div>
@@ -422,4 +422,3 @@
     </div>
   </div>
 </div>
-


### PR DESCRIPTION
This PR fixes the details button by adding the `on-oj-action` attribute and renaming the button to 'Edit'