### PR TITLE
Feat: Add Redwood Calendar View for Activities

### DIFF
--- a/webApps/app/flows/opportunities/pages/opportunities-details-page.json
+++ b/webApps/app/flows/opportunities/pages/opportunities-details-page.json
@@ -19,7 +19,7 @@
     },
     "activitiesViewType": {
       "type": "string",
-      "defaultValue": "activities-list"
+      "defaultValue": "activities-calendar"
     },
     "activityCompletedList": {
       "type": "application:activityType[]",


### PR DESCRIPTION
This PR introduces a Redwood calendar view for activities and appointments, integrating directly with the activities module in Fusion.

**Changes Made:**
- Updated `webApps/app/flows/opportunities/pages/opportunities-details-page.json` to set the default view for activities to the calendar view.