### PR TITLE
feat: Implement Redwood Calendar View for Activities

### DIFF
--- a/webApps/app/flows/opportunities/pages/opportunities-details-page-chains/vbEnterListener.js
+++ b/webApps/app/flows/opportunities/pages/opportunities-details-page-chains/vbEnterListener.js
@@ -21,6 +21,10 @@ define([
       await Actions.callChain(context, {
         chain: 'fetchActivitiesActionChain',
       });
+
+      const allActivities = [...$variables.activityPendingList, ...$variables.activityCompletedList];
+
+      $variables.calendarEventsList = $page.functions.transformActivitiesToCalendarEvents(allActivities);
     }
   }
 

--- a/webApps/app/flows/opportunities/pages/opportunities-details-page.html
+++ b/webApps/app/flows/opportunities/pages/opportunities-details-page.html
@@ -549,8 +549,15 @@
               </oj-bind-for-each>
             </oj-bind-if>
             <oj-bind-if test='[[ $variables.activitiesViewType === "activities-calendar" ]]'>
-              <oj-sp-calendar calendar-events="[[ $variables.calendarEventsListADP ]]"
-                visible-calendars='["appointments"]' calendar-providers='[{"name":"appointments","color":"blue"}]'></oj-sp-calendar>
+                <oj-sp-calendar
+                  id="calendar"
+                  class="oj-flex-item oj-sm-flex-initial"
+                  date="[[ $variables.calendarDate ]]"
+                  view="month"
+                  calendar-events="[[ $variables.calendarEventsListADP ]]"
+                  on-oj-click="[[ $listeners.onCalendarClick ]]"
+                  style="width: 100%; height: 100%;">
+                </oj-sp-calendar>
             </oj-bind-if>
           </div>
         </div>

--- a/webApps/app/flows/opportunities/pages/opportunities-details-page.js
+++ b/webApps/app/flows/opportunities/pages/opportunities-details-page.js
@@ -1,4 +1,4 @@
-define(["ojs/ojarraydataprovider"], function (ArrayDataProvider) {
+define(["ojs/ojcore", "knockout", "ojs/ojarraydataprovider"], function (oj, ko, ArrayDataProvider) {
   'use strict';
 
   const actionTypesMap = new Map();
@@ -6,6 +6,11 @@ define(["ojs/ojarraydataprovider"], function (ArrayDataProvider) {
   const activitiesMap = new Map();
 
   class PageModule {
+
+    constructor() {
+      this.calendarDate = ko.observable(new Date().toISOString());
+    }
+
     createADP(items, key) {
       return new ArrayDataProvider(items, { keyAttributes: key });
     }
@@ -169,6 +174,26 @@ define(["ojs/ojarraydataprovider"], function (ArrayDataProvider) {
       // result.sort((a, b) => (a.id > b.id ? -1 : 1));
 
       return result;
+    }
+
+    onCalendarClick(event) {
+      console.log("Calendar clicked", event.detail);
+    }
+
+    transformActivitiesToCalendarEvents(activities) {
+      if (!activities) {
+        return [];
+      }
+      return activities.map(activity => {
+        return {
+          id: activity.id,
+          title: activity.title,
+          start: activity.activityDate,
+          end: activity.activityDate,
+          calendar: 'appointments',
+          color: 'blue'
+        };
+      });
     }
   }
 

--- a/webApps/app/flows/opportunities/pages/opportunities-details-page.json
+++ b/webApps/app/flows/opportunities/pages/opportunities-details-page.json
@@ -23,7 +23,7 @@
     },
     "activityCompletedList": {
       "type": "application:activityType[]",
-      "defaultValue": "[[ [\n            {\n                \"id\": 4,\n                \"activityDate\": \"2/6/26\",\n                \"activityOrder\": 1,\n                \"activityStatus\": \"Completed\",\n                \"description\": null,\n                \"icon\": \"oj-ux-ico-phone-on\",\n                \"title\": \"Discovery Call\",\n                \"activityType\": \"LOG\",\n                \"dueDate\": null,\n                \"objectId\": 1,\n                \"content\": null,\n                \"owner\": \"Sales Rep\",\n                \"activityTime\": \"10:00 AM\"\n            },\n            {\n                \"id\": 3,\n                \"activityDate\": \"2/4/26\",\n                \"activityOrder\": 1,\n                \"activityStatus\": \"Completed\",\n                \"description\": null,\n                \"icon\": \"oj-ux-ico-email\",\n                \"title\": \"Intro Email\",\n                \"activityType\": \"LOG\",\n                \"dueDate\": null,\n                \"objectId\": 1,\n                \"content\": null,\n                \"owner\": \"Sales Rep\",\n                \"activityTime\": \"9:00 AM\"\n            },            {\n                \"id\": 2,\n                \"activityDate\": \"2/2/26\",\n                \"activityOrder\": 1,\n                \"activityStatus\": \"Completed\",\n                \"description\": null,\n                \"icon\": \"oj-ux-ico-chart-funnel-v\",\n                \"title\": \"Opportunity Updated\",\n                \"activityType\": \"LOG\",\n                \"dueDate\": null,\n                \"objectId\": 1,\n                \"content\": null,\n                \"owner\": \"Sales Rep\",\n                \"activityTime\": \"12:00 PM\"\n            },\n            {\n                \"id\": 1,\n                \"activityDate\": \"2/2/26\",\n                \"activityOrder\": 1,\n                \"activityStatus\": \"Completed\",\n                \"description\": null,\n                \"icon\": \"oj-ux-ico-chart-funnel-v\",\n                \"title\": \"Opportunity Created\",\n                \"activityType\": \"LOG\",\n                \"dueDate\": null,\n                \"objectId\": 1,\n                \"content\": null,\n                \"owner\": \"Sales Rep\",\n                \"activityTime\": \"10:00 AM\"\n            }\n        ] ]]"
+      "defaultValue": "[[ [\n            {\n                \"id\": 4,\n                \"activityDate\": \"2/6/26\",\n                \"activityOrder\": 1,\n                \"activityStatus\": \"Completed\",\n                \"description\": null,\n                \"icon\": \"oj-ux-ico-phone-on\",\n                \"title\": \"Discovery Call\",\n                \"activityType\": \"LOG\",\n                \"dueDate\": null,\n                \"objectId\": 1,\n                \"content\": null,\n                \"owner\": \"Sales Rep\",\n                \"activityTime\": \"10:00 AM\"\n            },\n            {\n                \"id\": 3,\n                \"activityDate\": \"2/4/26\",\n                \"activityOrder\": 1,\n                \"activityStatus\": \"Completed\",\n                \"description\": null,\n                \"icon\": \"oj-ux-ico-email\",\n                \"title\": \"Intro Email\",\n                \"activityType\": \"LOG\",\n                \"dueDate\": null,\n                \"objectId\": 1,\n                \"content\": null,\n                \"owner\": \"Sales Rep\",\n                \"activityTime\": \"9:00 AM\"\n            },            {\n                \"id\": 2,\n                \"activityDate\": \"2/2/26\",\n                \"activityOrder\": 1,\n                \"activityStatus\": \"Completed\",\n                \"description\": null,\n                \"icon\": \"oj-ux-ico-chart-funnel-v\",\n                \"title\": \"Opportunity Updated\",\n                \"activityType\": \"LOG\",\n                \"dueDate\": null,\n                \"objectId\": 1,\n                \"content\": null,\n                'owner': 'Sales Rep',\n                'activityTime': '12:00 PM'\n            },\n            {\n                'id': 1,\n                'activityDate': '2/2/26',\n                'activityOrder': 1,\n                'activityStatus': 'Completed',\n                'description': null,\n                'icon': 'oj-ux-ico-chart-funnel-v',\n                'title': 'Opportunity Created',\n                'activityType': 'LOG',\n                'dueDate': null,\n                'objectId': 1,\n                'content': null,\n                'owner': 'Sales Rep',\n                'activityTime': '10:00 AM'\n            }\n        ] ]]"
     },
     "activityCompletedListADP": {
       "type": "vb/ArrayDataProvider2",
@@ -42,9 +42,13 @@
       },
       "type": "vb/ArrayDataProvider2"
     },
+    "calendarDate": {
+      "type": "string",
+      "defaultValue": ""
+    },
     "calendarEventsList": {
       "type": "object[]",
-      "defaultValue": "[[ [\n            {\n                \"id\": 1,\n                \"start\": \"2026-02-02T10:00:00.000\",\n                \"end\": \"2026-02-02T10:30:00.000\",\n                \"allDay\": false,\n                \"eventTitle\": \"Discovery Call\",\n                \"calendarProvider\": \"appointments\",\n                \"tertiaryText\": \"\",\n                \"metaText\": \"\",\n                \"icon\": \"oj-ux-ico-edit\",\n                \"iconLabel\": \"\"\n            }\n        ] ]]"
+      "defaultValue": "[[ [\n            {\n                'id': 1,\n                'start': '2026-02-02T10:00:00.000',\n                'end': '2026-02-02T10:30:00.000',\n                'allDay': false,\n                'eventTitle': 'Discovery Call',\n                'calendarProvider': 'appointments',\n                'tertiaryText': '',\n                'metaText': '',\n                'icon': 'oj-ux-ico-edit',\n                'iconLabel': ''\n            }\n        ] ]]"
     },
     "calendarEventsListADP": {
       "type": "vb/ArrayDataProvider2",
@@ -59,7 +63,7 @@
     },
     "contactsList": {
       "type": "application:optyContactType[]",
-      "defaultValue": "[[ [\n            {\n                \"id\": 1,\n                \"name\": \"Bill Richardson\",\n                \"jobTitle\": \"VP, IT\",\n                \"email\": \"bill.richardson@oracledemos.com\",\n                \"optyId\": 1,\n                \"primaryContactFlag\": true,\n                \"phoneNumber\": \"+1 (512) 555-4542\"\n            },\n            {\n                \"id\": 2,\n                \"name\": \"James Brown\",\n                \"jobTitle\": \"IT Director\",\n                \"email\": \"james.brown@oracledemos.com\",\n                \"optyId\": 1,\n                \"primaryContactFlag\": false,\n                \"phoneNumber\": \"+1 (512) 555-4544\"\n            }\n        ] ]]"
+      "defaultValue": "[[ [\n            {\n                'id': 1,\n                'name': 'Bill Richardson',\n                'jobTitle': 'VP, IT',\n                'email': 'bill.richardson@oracledemos.com',\n                'optyId': 1,\n                'primaryContactFlag': true,\n                'phoneNumber': '+1 (512) 555-4542'\n            },\n            {\n                'id': 2,\n                'name': 'James Brown',\n                'jobTitle': 'IT Director',\n                'email': 'james.brown@oracledemos.com',\n                'optyId': 1,\n                'primaryContactFlag': false,\n                'phoneNumber': '+1 (512) 555-4544'\n            }\n        ] ]]"
     },
     "contactsListADP": {
       "type": "vb/ArrayDataProvider2",
@@ -169,7 +173,7 @@
     },
     "teamList": {
       "type": "application:teamType[]",
-      "defaultValue": "[[ [\n    {\n        \"id\": 1,\n        \"email\": \"sales.rep@oracledemos.com\",\n        \"name\": \"Sales Rep\",\n        \"phoneNumber\": \"+1 (512) 555-7477\",\n        \"jobTitle\": \"Sales Rep\",\n        \"ownerFlag\": true\n      \n    }\n] ]]"
+      "defaultValue": "[[ [\n    {\n        'id': 1,\n        'email': 'sales.rep@oracledemos.com',\n        'name': 'Sales Rep',\n        'phoneNumber': '+1 (512) 555-7477',\n        'jobTitle': 'Sales Rep',\n        'ownerFlag': true\n      \n    }\n] ]]"
     },
     "teamListADP": {
       "type": "vb/ArrayDataProvider2",
@@ -211,6 +215,9 @@
           }
         }
       ]
+    },
+    "onCalendarClick": {
+      "chains": []
     },
     "vbEnter": {
       "chains": [
@@ -268,6 +275,9 @@
       }
     },
     "modules": {
+      "knockout": {
+        "path": "knockout"
+      },
       "ojValidationNumber": {
         "path": "ojs/ojvalidation-number"
       }


### PR DESCRIPTION
This PR introduces a new calendar view for activities and appointments on the opportunities detail page.

The calendar view is implemented using the `oj-sp-calendar` component and is integrated with the existing activities data.

Changes include:
- Updated `opportunities-details-page.html` to add the calendar component.
- Updated `opportunities-details-page.js` to add logic for handling calendar data and events.
- Updated `opportunities-details-page.json` to include new variables and event listeners.
- Updated `vbEnterListener.js` to populate the calendar with data on page load.