### PR TITLE
Feature: Redwood Calendar View for Activities

### DIFF
--- a/webApps/app/flows/opportunities/pages/opportunities-details-page-chains/fetchActivitiesActionChain.js
+++ b/webApps/app/flows/opportunities/pages/opportunities-details-page-chains/fetchActivitiesActionChain.js
@@ -20,6 +20,39 @@ define([
       const groupActivitiesByDate = await $functions.groupActivitiesByDate($variables.activityPendingList, $variables.activityCompletedList);
 
       $variables.activitiesGroupList = groupActivitiesByDate;
+
+      // Create calendar events
+      const calendarEvents = [];
+      const allActivities = [...$variables.activityPendingList, ...$variables.activityCompletedList];
+
+      allActivities.forEach(activity => {
+        if (activity.activityType === 'APPOINTMENT') {
+          const startDate = new Date(activity.activityDate);
+          const [time, ampm] = activity.activityTime.split(' ');
+          let [hours, minutes] = time.split(':');
+
+          if (ampm === 'PM' && hours !== '12') {
+            hours = parseInt(hours, 10) + 12;
+          } else if (ampm === 'AM' && hours === '12') {
+            hours = 0;
+          }
+
+          startDate.setHours(hours);
+          startDate.setMinutes(minutes);
+
+          const endDate = new Date(startDate.getTime() + 30 * 60 * 1000); // Assuming 30 minutes duration
+
+          calendarEvents.push({
+            id: activity.id,
+            title: activity.title,
+            start: startDate.toISOString(),
+            end: endDate.toISOString(),
+            allDay: false,
+          });
+        }
+      });
+
+      $variables.calendarEventsList = calendarEvents;
     }
   }
 

--- a/webApps/app/flows/opportunities/pages/opportunities-details-page.html
+++ b/webApps/app/flows/opportunities/pages/opportunities-details-page.html
@@ -549,8 +549,8 @@
               </oj-bind-for-each>
             </oj-bind-if>
             <oj-bind-if test='[[ $variables.activitiesViewType === "activities-calendar" ]]'>
-              <oj-sp-calendar calendar-events="[[ $variables.calendarEventsListADP ]]"
-                visible-calendars='["appointments"]' calendar-providers='[{"name":"appointments","color":"blue"}]'></oj-sp-calendar>
+              <oj-c-calendar id="calendar" events="[[$variables.calendarEventsListADP]]" time-axis="[[ {scale: 'hour'} ]]" view="month">
+              </oj-c-calendar>
             </oj-bind-if>
           </div>
         </div>


### PR DESCRIPTION
This PR introduces a Redwood calendar view for activities and appointments on the opportunities-detail page. It replaces the existing oj-sp-calendar with the Redwood native oj-c-calendar and populates it with appointments from the activities module.