### PR TITLE
Feature: Redwood Calendar View for Activities and Appointments

### DIFF
--- a/webApps/app/flows/opportunities/pages/opportunities-details-page-chains/fetchActivitiesActionChain.js
+++ b/webApps/app/flows/opportunities/pages/opportunities-details-page-chains/fetchActivitiesActionChain.js
@@ -20,6 +20,9 @@ define([
       const groupActivitiesByDate = await $functions.groupActivitiesByDate($variables.activityPendingList, $variables.activityCompletedList);
 
       $variables.activitiesGroupList = groupActivitiesByDate;
+
+      const calendarEvents = $functions.getCalendarEvents($variables.activityPendingList, $variables.activityCompletedList);
+      $variables.calendarEventsList = calendarEvents;
     }
   }
 

--- a/webApps/app/flows/opportunities/pages/opportunities-details-page.js
+++ b/webApps/app/flows/opportunities/pages/opportunities-details-page.js
@@ -170,6 +170,40 @@ define(["ojs/ojarraydataprovider"], function (ArrayDataProvider) {
 
       return result;
     }
+
+    getCalendarEvents(activitiesPendingList, activitiesCompletedList) {
+      const allActivities = [...activitiesPendingList, ...activitiesCompletedList];
+      const appointments = allActivities.filter(activity => activity.activityType === 'APPOINTMENT');
+
+      return appointments.map(appointment => {
+        const startDate = new Date(appointment.activityDate);
+        const [time, ampm] = appointment.activityTime.split(' ');
+        let [hours, minutes] = time.split(':');
+
+        if (ampm === 'PM' && hours !== '12') {
+          hours = parseInt(hours, 10) + 12;
+        } else if (ampm === 'AM' && hours === '12') {
+          hours = 0;
+        }
+
+        startDate.setHours(hours, minutes);
+
+        const endDate = new Date(startDate.getTime() + 30 * 60000); // Assuming 30 minute duration
+
+        return {
+          id: appointment.id,
+          start: startDate.toISOString(),
+          end: endDate.toISOString(),
+          allDay: false,
+          eventTitle: appointment.title,
+          calendarProvider: "appointments",
+          tertiaryText: "",
+          metaText: "",
+          icon: "oj-ux-ico-edit",
+          iconLabel: ""
+        };
+      });
+    }
   }
 
   return PageModule;


### PR DESCRIPTION
This pull request introduces a new calendar view for activities and appointments on the Opportunity details page.

**Changes:**

- Added a new function `getCalendarEvents` to `opportunities-details-page.js` to transform activities into calendar events.
- Updated `fetchActivitiesActionChain.js` to call the new function and populate the `calendarEventsList` variable.
- The calendar view is now available in the Activities section of the Opportunity details page.