### PR TITLE
Feature: Redwood Calendar View for Activities and Appointments

### DIFF
--- a/webApps/app/flows/opportunities/pages/opportunities-details-page.html
+++ b/webApps/app/flows/opportunities/pages/opportunities-details-page.html
@@ -30,7 +30,7 @@
             <span class="oj-text-color-secondary oj-sm-padding-1x-end">Status</span>
             <span><oj-bind-text value="[[ $flow.variables.opty.status ]]"></oj-bind-text></span>
           </div>
-          <div class="oj-flex oj-sm-align-items.center oj-sm-justify-content-center oj-sm-padding-4x-start">
+          <div class="oj-flex oj-sm-align-items-center oj-sm-justify-content-center oj-sm-padding-4x-start">
             <span class="oj-text-color-secondary oj-sm-padding-1x-end">Predicted Win Probability</span>
             <a>
               <oj-bind-text value="[[ $flow.variables.opty.predWinProb ]]"></oj-bind-text>
@@ -549,7 +549,7 @@
               </oj-bind-for-each>
             </oj-bind-if>
             <oj-bind-if test='[[ $variables.activitiesViewType === "activities-calendar" ]]'>
-              <oj-sp-calendar id="calendar" activity-data="[[ $variables.activitiesGroupListADP ]]"
+              <oj-sp-calendar id="calendar" activity-data="[[ $variables.calendarActivitiesADP ]]"
                 class="oj-flex-item oj-sm-flex-initial">
               </oj-sp-calendar>
             </oj-bind-if>

--- a/webApps/app/flows/opportunities/pages/opportunities-details-page.html
+++ b/webApps/app/flows/opportunities/pages/opportunities-details-page.html
@@ -30,7 +30,7 @@
             <span class="oj-text-color-secondary oj-sm-padding-1x-end">Status</span>
             <span><oj-bind-text value="[[ $flow.variables.opty.status ]]"></oj-bind-text></span>
           </div>
-          <div class="oj-flex oj-sm-align-items-center oj-sm-justify-content-center oj-sm-padding-4x-start">
+          <div class="oj-flex oj-sm-align-items.center oj-sm-justify-content-center oj-sm-padding-4x-start">
             <span class="oj-text-color-secondary oj-sm-padding-1x-end">Predicted Win Probability</span>
             <a>
               <oj-bind-text value="[[ $flow.variables.opty.predWinProb ]]"></oj-bind-text>
@@ -547,6 +547,11 @@
                   </oj-accordion>
                 </template>
               </oj-bind-for-each>
+            </oj-bind-if>
+            <oj-bind-if test='[[ $variables.activitiesViewType === "activities-calendar" ]]'>
+              <oj-sp-calendar id="calendar" activity-data="[[ $variables.activitiesGroupListADP ]]"
+                class="oj-flex-item oj-sm-flex-initial">
+              </oj-sp-calendar>
             </oj-bind-if>
           </div>
         </div>

--- a/webApps/app/flows/opportunities/pages/opportunities-details-page.js
+++ b/webApps/app/flows/opportunities/pages/opportunities-details-page.js
@@ -170,6 +170,17 @@ define(["ojs/ojarraydataprovider"], function (ArrayDataProvider) {
 
       return result;
     }
+
+    getActivitiesForCalendar(activitiesPendingList, activitiesCompletedList) {
+      const allActivities = [...activitiesPendingList, ...activitiesCompletedList];
+      return allActivities.map(activity => {
+        return {
+          ...activity,
+          start: new Date(activity.activityDate).toISOString(),
+          end: new Date(activity.activityDate).toISOString(),
+        };
+      });
+    }
   }
 
   return PageModule;

--- a/webApps/app/flows/opportunities/pages/opportunities-details-page.json
+++ b/webApps/app/flows/opportunities/pages/opportunities-details-page.json
@@ -42,6 +42,17 @@
       },
       "type": "vb/ArrayDataProvider2"
     },
+    "calendarActivities": {
+      "type": "application:activityType[]"
+    },
+    "calendarActivitiesADP": {
+      "type": "vb/ArrayDataProvider2",
+      "defaultValue": {
+        "data": "{{ $variables.calendarActivities }}",
+        "itemType": "application:activityType",
+        "keyAttributes": "id"
+      }
+    },
     "contactsCount": {
       "type": "number",
       "defaultValue": 2


### PR DESCRIPTION
This PR introduces a new calendar view for activities and appointments on the opportunities details page.

**Changes:**
- Added a calendar view to the activities tab.
- The calendar view is powered by the `oj-sp-calendar` component.
- The activity data is flattened and formatted for the calendar.

**Files Modified:**
- `webApps/app/flows/opportunities/pages/opportunities-details-page.html`
- `webApps/app/flows/opportunities/pages/opportunities-details-page.json`
- `webApps/app/flows/opportunities/pages/opportunities-details-page.js`