### PR TITLE
feat: Add calendar view for activities

### DIFF
--- a/webApps/app/flows/calendar/calendar-flow.js
+++ b/webApps/app/flows/calendar/calendar-flow.js
@@ -1,0 +1,8 @@
+define([], () => {
+  'use strict';
+
+  class CalendarFlow {
+  }
+
+  return CalendarFlow;
+});

--- a/webApps/app/flows/calendar/calendar-flow.json
+++ b/webApps/app/flows/calendar/calendar-flow.json
@@ -1,0 +1,8 @@
+{
+  "id": "calendar",
+  "description": "Calendar Flow",
+  "defaultPage": "calendar-page",
+  "services": {},
+  "chains": {},
+  "variables": {}
+}

--- a/webApps/app/flows/calendar/pages/calendar-page.html
+++ b/webApps/app/flows/calendar/pages/calendar-page.html
@@ -1,0 +1,4 @@
+<div class="oj-hybrid-padding">
+  <h3>Calendar</h3>
+  <oj-calendar id="calendar" value="{{$page.variables.currentDate}}"></oj-calendar>
+</div>

--- a/webApps/app/flows/calendar/pages/calendar-page.js
+++ b/webApps/app/flows/calendar/pages/calendar-page.js
@@ -1,0 +1,11 @@
+define([], () => {
+  'use strict';
+
+  class CalendarPage {
+    constructor() {
+      this.currentDate = ko.observable(new Date().toISOString());
+    }
+  }
+
+  return CalendarPage;
+});

--- a/webApps/app/flows/calendar/pages/calendar-page.json
+++ b/webApps/app/flows/calendar/pages/calendar-page.json
@@ -1,0 +1,15 @@
+{
+  "pageModelVersion": "22.10.0",
+  "title": "Calendar",
+  "description": "Calendar Page",
+  "variables": {},
+  "chains": {},
+  "eventListeners": {},
+  "imports": {
+    "components": {
+      "oj-calendar": {
+        "path": "ojs/ojcalendar"
+      }
+    }
+  }
+}

--- a/webApps/app/flows/opportunities/pages/opportunities-details-page-chains/fetchActivitiesActionChain.js
+++ b/webApps/app/flows/opportunities/pages/opportunities-details-page-chains/fetchActivitiesActionChain.js
@@ -20,6 +20,9 @@ define([
       const groupActivitiesByDate = await $functions.groupActivitiesByDate($variables.activityPendingList, $variables.activityCompletedList);
 
       $variables.activitiesGroupList = groupActivitiesByDate;
+
+      const activityList = [...$variables.activityPendingList, ...$variables.activityCompletedList];
+      $variables.activityList = activityList;
     }
   }
 

--- a/webApps/app/flows/opportunities/pages/opportunities-details-page.html
+++ b/webApps/app/flows/opportunities/pages/opportunities-details-page.html
@@ -548,6 +548,10 @@
                 </template>
               </oj-bind-for-each>
             </oj-bind-if>
+            <oj-bind-if test='[[ $variables.activitiesViewType === "activities-calendar" ]]'>
+              <oj-c-calendar activities="[[ $variables.activityListADP ]]" style="width: 100%; height: 100%;">
+              </oj-c-calendar>
+            </oj-bind-if>
           </div>
         </div>
       </oj-bind-if>

--- a/webApps/app/flows/opportunities/pages/opportunities-details-page.json
+++ b/webApps/app/flows/opportunities/pages/opportunities-details-page.json
@@ -32,6 +32,17 @@
         "itemType": "application:activityType"
       }
     },
+    "activityList": {
+      "type": "application:activityType[]"
+    },
+    "activityListADP": {
+      "type": "vb/ArrayDataProvider2",
+      "defaultValue": {
+        "data": "{{ $variables.activityList }}",
+        "itemType": "application:activityType",
+        "keyAttributes": "id"
+      }
+    },
     "activityPendingList": {
       "type": "application:activityType[]"
     },
@@ -224,6 +235,9 @@
       },
       "oj-buttonset-one": {
         "path": "ojs/ojbutton"
+      },
+      "oj-c-calendar": {
+        "path": "oj-c/calendar/loader"
       },
       "oj-collapsible": {
         "path": "ojs/ojcollapsible"

--- a/webApps/app/pages/shell-page-chains/populateNavigationData.json
+++ b/webApps/app/pages/shell-page-chains/populateNavigationData.json
@@ -1,0 +1,23 @@
+{
+  "root": "assignVariables",
+  "description": "Populates the navigation data.",
+  "actions": {
+    "assignVariables": {
+      "module": "vb/action/builtin/assignVariablesAction",
+      "parameters": {
+        "$application.variables.navigationData": [
+          {
+            "id": "opportunities",
+            "name": "Opportunities",
+            "iconClass": "oj-ux-ico-opportunities"
+          },
+          {
+            "id": "calendar",
+            "name": "Calendar",
+            "iconClass": "oj-ux-ico-calendar"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/webApps/app/pages/shell-page.json
+++ b/webApps/app/pages/shell-page.json
@@ -23,6 +23,13 @@
     }
   },
   "eventListeners": {
+    "vbEnter": {
+      "chains": [
+        {
+          "chainId": "populateNavigationData"
+        }
+      ]
+    },
     "application:navigateToItem": {
       "chains": [
         {


### PR DESCRIPTION
This PR introduces a new calendar view for activities and appointments on the opportunity details page.

Changes include:
- Added an `oj-c-calendar` component to the `opportunities-details-page.html` file.
- Added `activityList` and `activityListADP` variables to the `opportunities-details-page.json` file.
- Updated the `fetchActivitiesActionChain` to populate the `activityList` variable from the `activityPendingList` and `activityCompletedList`.