### PR TITLE
feat: Add calendar view for activities

### DIFF
--- a/webApps/app/flows/opportunities/pages/opportunities-details-page.html
+++ b/webApps/app/flows/opportunities/pages/opportunities-details-page.html
@@ -548,6 +548,9 @@
                 </template>
               </oj-bind-for-each>
             </oj-bind-if>
+             <oj-bind-if test='[[ $variables.activitiesViewType === "activities-calendar" ]]'>
+                <oj-calendar activities="[[$variables.activityListSDP]]" style="width:100%;height:100%"></oj-calendar>
+            </oj-bind-if>
           </div>
         </div>
       </oj-bind-if>


### PR DESCRIPTION
This pull request introduces a new calendar view for activities on the opportunities details page.

Changes include:
- Added an `<oj-calendar>` component to `opportunities-details-page.html`.
- The calendar is displayed when the user selects the calendar view option.
- The calendar is populated with data from the `activityListSDP` variable.