### PR TITLE
Feature: Add Redwood calendar view for activities

### DIFF
--- a/webApps/app/flows/opportunities/pages/opportunities-details-page-chains/fetchActivitiesActionChain.js
+++ b/webApps/app/flows/opportunities/pages/opportunities-details-page-chains/fetchActivitiesActionChain.js
@@ -17,7 +17,7 @@ define([
     async run(context) {
       const { $page, $flow, $application, $constants, $variables, $functions } = context;
 
-      const groupActivitiesByDate = await $functions.groupActivitiesByDate($variables.activityPendingList, $variables.activityCompletedList);
+      const groupActivitiesByDate = await $functions.groupActivitiesByDate($page, $variables.activityPendingList, $variables.activityCompletedList);
 
       $variables.activitiesGroupList = groupActivitiesByDate;
     }

--- a/webApps/app/flows/opportunities/pages/opportunities-details-page.html
+++ b/webApps/app/flows/opportunities/pages/opportunities-details-page.html
@@ -548,6 +548,10 @@
                 </template>
               </oj-bind-for-each>
             </oj-bind-if>
+             <oj-bind-if test='[[ $variables.activitiesViewType === "activities-calendar" ]]'>
+                <oj-calendar id="calendar" activities="[[ $variables.activityCalendarADP ]]" class="oj-flex-item oj-flex">
+                </oj-calendar>
+            </oj-bind-if>
           </div>
         </div>
       </oj-bind-if>

--- a/webApps/app/flows/opportunities/pages/opportunities-details-page.js
+++ b/webApps/app/flows/opportunities/pages/opportunities-details-page.js
@@ -91,7 +91,21 @@ define(["ojs/ojarraydataprovider"], function (ArrayDataProvider) {
       return month + " " + day + ", " + year;
     }
 
-    groupActivitiesByDate(activitiesPendingList, activitiesCompletedList) {
+    getCalendarActivities(activities) {
+      return activities.map(activity => {
+        const activityDate = new Date(activity.activityDate);
+        const start = new Date(activityDate.getFullYear(), activityDate.getMonth(), activityDate.getDate(), 9, 0, 0); // Default to 9:00 AM
+        const end = new Date(activityDate.getFullYear(), activityDate.getMonth(), activityDate.getDate(), 10, 0, 0); // Default to 10:00 AM
+        return {
+          id: activity.id,
+          title: activity.title,
+          start: start.toISOString(),
+          end: end.toISOString(),
+        };
+      });
+    }
+
+    groupActivitiesByDate(page, activitiesPendingList, activitiesCompletedList) {
       let activitiesPendingListCopy = JSON.parse(JSON.stringify(activitiesPendingList));
       let activitiesCompletedListCopy = JSON.parse(JSON.stringify(activitiesCompletedList));
 
@@ -164,6 +178,10 @@ define(["ojs/ojarraydataprovider"], function (ArrayDataProvider) {
         activitiesGroupMap.set(activityGroup.id, activityGroup);
         idCounter++;
       }
+
+      const allActivities = [...activitiesPendingListCopy, ...activitiesCompletedListCopy];
+      const calendarActivities = this.getCalendarActivities(allActivities);
+      page.variables.activityCalendarADP = new ArrayDataProvider(calendarActivities, { keyAttributes: 'id' });
 
       let result = Array.from(activitiesGroupMap.values());
       // result.sort((a, b) => (a.id > b.id ? -1 : 1));

--- a/webApps/app/flows/opportunities/pages/opportunities-details-page.json
+++ b/webApps/app/flows/opportunities/pages/opportunities-details-page.json
@@ -21,6 +21,14 @@
       "type": "string",
       "defaultValue": "activities-list"
     },
+    "activityCalendarADP": {
+      "type": "vb/ArrayDataProvider2",
+      "defaultValue": {
+        "data": "[]",
+        "itemType": "application:activityType",
+        "keyAttributes": "id"
+      }
+    },
     "activityCompletedList": {
       "type": "application:activityType[]",
       "defaultValue": "[[ [\n            {\n                \"id\": 4,\n                \"activityDate\": \"2/6/26\",\n                \"activityOrder\": 1,\n                \"activityStatus\": \"Completed\",\n                \"description\": null,\n                \"icon\": \"oj-ux-ico-phone-on\",\n                \"title\": \"Discovery Call\",\n                \"activityType\": \"LOG\",\n                \"dueDate\": null,\n                \"objectId\": 1,\n                \"content\": null,\n                \"owner\": \"Sales Rep\",\n                \"activityTime\": \"10:00 AM\"\n            },\n            {\n                \"id\": 3,\n                \"activityDate\": \"2/4/26\",\n                \"activityOrder\": 1,\n                \"activityStatus\": \"Completed\",\n                \"description\": null,\n                \"icon\": \"oj-ux-ico-email\",\n                \"title\": \"Intro Email\",\n                \"activityType\": \"LOG\",\n                \"dueDate\": null,\n                \"objectId\": 1,\n                \"content\": null,\n                \"owner\": \"Sales Rep\",\n                \"activityTime\": \"9:00 AM\"\n            },            {\n                \"id\": 2,\n                \"activityDate\": \"2/2/26\",\n                \"activityOrder\": 1,\n                \"activityStatus\": \"Completed\",\n                \"description\": null,\n                \"icon\": \"oj-ux-ico-chart-funnel-v\",\n                \"title\": \"Opportunity Updated\",\n                \"activityType\": \"LOG\",\n                \"dueDate\": null,\n                \"objectId\": 1,\n                \"content\": null,\n                \"owner\": \"Sales Rep\",\n                \"activityTime\": \"12:00 PM\"\n            },\n            {\n                \"id\": 1,\n                \"activityDate\": \"2/2/26\",\n                \"activityOrder\": 1,\n                \"activityStatus\": \"Completed\",\n                \"description\": null,\n                \"icon\": \"oj-ux-ico-chart-funnel-v\",\n                \"title\": \"Opportunity Created\",\n                \"activityType\": \"LOG\",\n                \"dueDate\": null,\n                \"objectId\": 1,\n                \"content\": null,\n                \"owner\": \"Sales Rep\",\n                \"activityTime\": \"10:00 AM\"\n            }\n        ] ]]"
@@ -224,6 +232,9 @@
       },
       "oj-buttonset-one": {
         "path": "ojs/ojbutton"
+      },
+      "oj-calendar": {
+        "path": "ojs/ojcalendar"
       },
       "oj-collapsible": {
         "path": "ojs/ojcollapsible"


### PR DESCRIPTION
This PR introduces a new calendar view for activities on the opportunity details page.

The following changes have been made:
- Added an `oj-calendar` component to the `opportunities-details-page.html` file.
- Added a new `activityCalendarADP` variable to the `opportunities-details-page.json` file to serve as the data provider for the calendar.
- Updated the `opportunities-details-page.js` file with a new function to process and format the activity data for the calendar.
- Updated the `fetchActivitiesActionChain.js` to pass the page context to the data processing function.